### PR TITLE
update docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kalilinux/kali-linux-docker
+FROM kalilinux/kali-rolling
 MAINTAINER Ryan Ringler <rringler@gmail.com>
 
 # Add Xwindows configuration


### PR DESCRIPTION
`kali-linux-docker` is deprecated.

https://hub.docker.com/r/kalilinux/kali-linux-docker